### PR TITLE
Update special character list

### DIFF
--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -2,8 +2,6 @@ const isName = str => /^$|^[A-zÀ-ú\- ]+$/.test(str)
 
 const isUsername = str => /^[\w!?$#@()\-*]+$/.test(str)
 
-const isPassword = str => /^([a-zA-Z\d!?$#%@()\\\-*_/@^+*&:<>:{};~'.|[\]])+$/.test(str)
-
 const getForce = str => {
   const info = getPasswordInfo(str)
   return str.length < 6 ? 0 : computeScore(info)
@@ -17,7 +15,7 @@ const containLowercase = str => /[a-z]/.test(str)
 
 const containNumber = str => /[0-9]/.test(str)
 
-const containSpecialCharacter = str => /[!?$#%@()\\\-*_/@^+*&:<>:{};~'.|[\]]/.test(str)
+const containSpecialCharacter = str => /[="!?$#%@()\\\-_/@^+*&:<>{};~'`.|[\]]/.test(str)
 
 const getPasswordInfo = str => ({
   lowercase: containLowercase(str),

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -27,4 +27,4 @@ const getPasswordInfo = str => ({
 
 const computeScore = info => Object.keys(info).reduce((acc, cur) => acc + (info[cur] ? 1 : 0), 0)
 
-export { isName, isUsername, isPassword, getPasswordInfo, getForce, isForceEnough }
+export { isName, isUsername, getPasswordInfo, getForce, isForceEnough }

--- a/src/modals/PasswordEdit/PasswordEdit.jsx
+++ b/src/modals/PasswordEdit/PasswordEdit.jsx
@@ -5,7 +5,7 @@ import { withTranslation } from 'react-i18next'
 
 import { updatePassphrase, setNotification } from '../../actions'
 import { Modal, Button, TextField, Typography, Space, PasswordStrength } from '../../components'
-import { isPassword, isForceEnough } from '../../lib/validators'
+import { isForceEnough } from '../../lib/validators'
 
 import styles from './PasswordEdit.module.scss'
 
@@ -41,7 +41,7 @@ class PasswordEdit extends React.Component {
     }
 
     switch (fieldName) {
-      case 'password': return isPassword(field) && isForceEnough(field) && this.state.password !== this.state.currentPassword
+      case 'password': return isForceEnough(field) && this.state.password !== this.state.currentPassword
       case 'passwordConfirmation': return field === this.state.password
       default: return false
     }
@@ -62,8 +62,7 @@ class PasswordEdit extends React.Component {
       currentPasswordError: false
     })
 
-    if (!isPassword(password) ||
-        !isForceEnough(password) ||
+    if (!isForceEnough(password) ||
         (password === currentPassword)) {
       return this.setState({
         showErrors: true

--- a/src/modals/Signup/Signup.jsx
+++ b/src/modals/Signup/Signup.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { withTranslation } from 'react-i18next'
 import { setNotification } from '../../actions'
 import { Avatar, Modal, Button, TextField, Typography, Space, PasswordStrength } from '../../components'
-import { isName, isUsername, isPassword, isForceEnough } from '../../lib/validators'
+import { isName, isUsername, isForceEnough } from '../../lib/validators'
 import { isUsernameAlreadyTaken, compressImage, MAX_IMAGE_SIZE } from '../../lib/utils'
 
 import styles from './Signup.module.scss'
@@ -47,7 +47,7 @@ class Signup extends React.Component {
       case 'firstname': return isName(field)
       case 'lastname': return isName(field)
       case 'username': return isUsername(field) && !isUsernameAlreadyTaken(field)
-      case 'password': return isPassword(field) && isForceEnough(field)
+      case 'password': return isForceEnough(field)
       case 'passwordConfirmation': return field === this.state.password
       default: return false
     }

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const { isName, isUsername, isPassword, getPasswordInfo, getForce, isForceEnough } = require('../src/lib/validators')
+const { isName, isUsername, getPasswordInfo, getForce, isForceEnough } = require('../src/lib/validators')
 
 describe('name validator', () => {
   it('should be valid', () => {
@@ -62,32 +62,6 @@ describe('username validator', () => {
   })
 })
 
-describe('password validator (check only authoried caracters)', () => {
-  it('should be valid', () => {
-    const str = 'somePassword9$'
-    expect(isPassword(str)).to.be.true
-  })
-
-  it('should be valid', () => {
-    const str = '!?$#%@()\\-*/@^+*&:<>:{};~\'.|'
-    expect(isPassword(str)).to.be.true
-  })
-
-  it('empty is forbbiden', () => {
-    expect(isPassword('')).to.be.false
-  })
-
-  it('spaces are forbidden', () => {
-    const str = 'some Password9$'
-    expect(isPassword(str)).to.be.false
-  })
-
-  it('not authorized special caracters are forbidden', () => {
-    const str = 'shor²'
-    expect(isPassword(str)).to.be.false
-  })
-})
-
 describe('password rules checker', () => {
   it('should return true if password contains lowercase', () => {
     const str = 'somePassword9$'
@@ -100,6 +74,26 @@ describe('password rules checker', () => {
   it('should return true if password contains specialCharacter', () => {
     const str = 'somePassword9$'
     expect(getPasswordInfo(str).specialCharacter).to.be.true
+  })
+  it('should return true if password contains specialCharacter', () => {
+    const str = 'somePassword9$'
+    expect(getPasswordInfo(str).specialCharacter).to.be.true
+  })
+  it('should return true if password contains specialCharacter =', () => {
+    const str = 'somePassword9='
+    expect(getPasswordInfo(str).specialCharacter).to.be.true
+  })
+  it('should return true if password contains specialCharacter `', () => {
+    const str = 'somePassword9`'
+    expect(getPasswordInfo(str).specialCharacter).to.be.true
+  })
+  it('should return true if password contains specialCharacter "', () => {
+    const str = 'somePassword9"'
+    expect(getPasswordInfo(str).specialCharacter).to.be.true
+  })
+  it('should return false if password contains a special Character not in the whitelist : ex ² "', () => {
+    const str = 'somePassword²'
+    expect(getPasswordInfo(str).specialCharacter).to.be.false
   })
   it('should return true if password contains number', () => {
     const str = 'somePassword9$'


### PR DESCRIPTION
We change the behaviour for the password rules : 

- We add =, " and ` in the special characters white-list
- We authorize all characters in the password, e.g. ² or " " (space)

Thanks to this PR, we will be able to login with a password containing different characters (ex ²) , if the given special characters is not in the white list, the one special character rule will not be filled, but the login process will not be blocked. 